### PR TITLE
Drichards sla endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,31 @@ public class ExampleMain {
 }
 ```
 
+# Setting up the SLA handler
+
+Example from a consumer service sending message timestamps to the `SlaClient` for verification.
+
+```java
+import com.krux.stdlib.utils.SlaClient;
+
+public class messageProcessor { 
+    
+    private static SlaClient _slaClient = SlaClient.getInstance();
+    
+    public onMessage(String message) {
+       // send the message to the sla client to determine if the sla has been met
+       SlaClient.checkTs(GifStreamParserUtil.getTSInMillis(recordParts));
+    }
+}
+```
+
+Testing the SLA endpoint
+
+```bash
+curl localhost:8080/__sla
+```
+
+
 This will setup slf4j (via log4j) bindings for stdout and stderr, establish a statsd client for use throughout your app via `KruxStdLib.STATSD`, and parse a standard set of command line options that all Krux apps should support. To see a list of the standard command line options, build an app that uses the stdlib as above, then pass '-h' or '--help' at the command line.  You will see output like...
 
 ```
@@ -71,6 +96,7 @@ Option                                       Description
 --stats-port [Integer]                       Listening statsd port (default: 8125)
 --property-file [String]                     Path to an external property file, containing names of external resources
                                              such that vary by environment, such as a database server hostname.
+--sla                                        SLA in seconds to return on the /__sla endpoint                                          
 ```
 
 In more advanced scenarios, you can specifiy custom command line options, set up shutdown hooks, tap into a standard HTTP listener and do other groovy things. See [a detailed example](https://github.com/krux/java-krux-stdlib/blob/master/src/main/java/com/krux/stdlib/sample/ExampleMain.java) for more complex uses.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.krux</groupId>
     <artifactId>krux-stdlib</artifactId>
-    <version>1.7.6</version>
+    <version>1.7.7</version>
     <packaging>jar</packaging>
 
     <name>krux-stdlib</name>

--- a/src/main/java/com/krux/server/http/StdHttpServerHandler.java
+++ b/src/main/java/com/krux/server/http/StdHttpServerHandler.java
@@ -9,7 +9,6 @@ import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
-
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;

--- a/src/main/java/com/krux/stdlib/KruxStdLib.java
+++ b/src/main/java/com/krux/stdlib/KruxStdLib.java
@@ -78,9 +78,6 @@ public class KruxStdLib {
 
     private static String _appDescription = null;
 
-    // holds the sla status value
-    public static Boolean isSlaMet = true;
-
     /**
      * If you'd like to utilize the std lib parser for your app-specific cli
      * argument parsing needs, feel free to pass a configured OptionParser to
@@ -240,7 +237,7 @@ public class KruxStdLib {
                     .withOptionalArg().ofType(String.class);
             /* the --property-file is parsed by Properties and the values are available via
                 ExternalProperties.getPropertyValue() */
-            OptionSpec<Integer> slaInSeconds = parser.accepts("sla-in-seconds",
+            OptionSpec<Integer> slaInSeconds = parser.accepts("sla",
                     "Sets the SLA in seconds for messages in kafka pipeline.")
                     .withOptionalArg().ofType(Integer.class).defaultsTo(slaInSecondsDefault);
 

--- a/src/main/java/com/krux/stdlib/utils/SlaClient.java
+++ b/src/main/java/com/krux/stdlib/utils/SlaClient.java
@@ -40,6 +40,9 @@ public class SlaClient {
             // want to make sure that the failure is seen by monitoring at
             // least once. At that time we flip it back to true.
             _isSlaMet = false;
+
+            // send a failure metric
+            KruxStdLib.STATSD.count("sla.failure");
         }
     }
 
@@ -54,8 +57,6 @@ public class SlaClient {
             Boolean status = _isSlaMet;
             // flip boolean back to true after seen by monitoring
             _isSlaMet = true;
-            // send a failure metric
-            KruxStdLib.STATSD.count("sla.failure");
             return status;
         }
         return _isSlaMet;

--- a/src/main/java/com/krux/stdlib/utils/SlaClient.java
+++ b/src/main/java/com/krux/stdlib/utils/SlaClient.java
@@ -1,0 +1,45 @@
+package com.krux.stdlib.utils;
+
+import com.krux.stdlib.KruxStdLib;
+
+
+/**
+ * Created by d.richards on 2/28/17.
+ */
+public class SlaClient {
+
+    // holds the SLA status value
+    private static Boolean _isSlaMet = true;
+    // holds the SLA value in millis
+    private static long _slaInMillis = KruxStdLib.SLA_IN_SECONDS * 1000;
+
+    // thread safe singleton class
+    private static class Loader {
+        static SlaClient INSTANCE = new SlaClient();
+    }
+    private SlaClient () {}
+    public static SlaClient getInstance() {
+        return Loader.INSTANCE;
+    }
+
+
+    static void checkTs(long timestamp) {
+
+        // get current time and subtract the sla in milliseconds
+        long slaMinTimestamp = System.currentTimeMillis() - _slaInMillis;
+
+        // if the message received time is outside the sla threshold
+        if ( timestamp < slaMinTimestamp ) {
+
+            // update the value of isSlaMet
+            _isSlaMet = false;
+        } else {
+            _isSlaMet = true;
+        }
+    }
+
+    public static Boolean isSlaMet() {
+        return _isSlaMet;
+    }
+}
+

--- a/src/main/java/com/krux/stdlib/utils/SlaClient.java
+++ b/src/main/java/com/krux/stdlib/utils/SlaClient.java
@@ -2,7 +2,6 @@ package com.krux.stdlib.utils;
 
 import com.krux.stdlib.KruxStdLib;
 
-
 /**
  * A client for determining if an application is running within the SLA
  *

--- a/src/test/java/com/krux/stdlib/utils/SlaClientTest.java
+++ b/src/test/java/com/krux/stdlib/utils/SlaClientTest.java
@@ -1,16 +1,13 @@
 package com.krux.stdlib.utils;
 
-import com.krux.stdlib.KruxStdLib;
-import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.buffer.Unpooled;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.net.URL;
 import static org.junit.Assert.assertEquals;
+
+import com.krux.stdlib.KruxStdLib;
 
 /**
  * Created by d.richards on 2/28/17.

--- a/src/test/java/com/krux/stdlib/utils/SlaClientTest.java
+++ b/src/test/java/com/krux/stdlib/utils/SlaClientTest.java
@@ -1,0 +1,112 @@
+package com.krux.stdlib.utils;
+
+import com.krux.stdlib.KruxStdLib;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.buffer.Unpooled;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by d.richards on 2/28/17.
+ */
+public class SlaClientTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger( ExternalProperties.class.getName() );
+
+    private static long failureTS;
+    private static long successTS;
+    private static KruxStdLib kruxStdLib;
+
+    @Before
+    public void setUp() throws Exception {
+
+        URL testPropertyFileURL = Thread.currentThread().getContextClassLoader().getResource("test_properties.properties");
+
+        // initialize
+        kruxStdLib = new KruxStdLib();
+        kruxStdLib.initialize(null, false, null, null, null, null, null, null, null, null, testPropertyFileURL.getPath());
+
+        // ensure the timestamp will fail by subtracting 1 milli from the oldest possible
+        // successful timestamp
+        failureTS = System.currentTimeMillis() - (KruxStdLib.SLA_IN_SECONDS * 1000) - 1;
+
+        // save a timestamp that should return a successful SLA status
+        successTS = System.currentTimeMillis();
+    }
+
+    @Test
+    public void verifySingletonStatusTest() {
+
+        // get the singleton class
+        SlaClient slaClient = SlaClient.getInstance();
+
+        // add the failing timestamp
+        slaClient.checkTs(failureTS);
+
+        // ensure the sla status has false
+        Boolean status = slaClient.isSlaMet();
+        assertEquals(false, status);
+
+        // get the singleton class again
+        SlaClient slaClient2 = SlaClient.getInstance();
+
+        // ensure the sla status is still failing
+        Boolean status2 = slaClient2.isSlaMet();
+        assertEquals(false, status2);
+    }
+
+    @Test
+    public void ensureNormalOperationTest() {
+
+        // get the singleton class
+        SlaClient slaClient = SlaClient.getInstance();
+
+        // send a timestamp that should return successful
+        slaClient.checkTs(successTS);
+
+        // check sla status
+        Boolean status = slaClient.isSlaMet();
+
+        // verify the success
+        assertEquals(true, status);
+    }
+
+    @Test
+    public void ensureThreadSafeTest() throws InterruptedException {
+
+        // setup testing class
+        class SingletonTestRunnable implements Runnable {
+            public void run() {
+                // Get a reference to the singleton.
+                SlaClient slaClient = SlaClient.getInstance();
+
+                assertEquals(false, slaClient.isSlaMet());
+            }
+        }
+
+        // insert a timestamp that should cause a SLA failure
+        SlaClient slaClient = SlaClient.getInstance();
+        slaClient.checkTs(failureTS);
+
+        // setup the threads
+        Thread threadOne = new Thread(new SingletonTestRunnable()),
+                threadTwo = new Thread(new SingletonTestRunnable()),
+                threadThree = new Thread(new SingletonTestRunnable());
+
+        // start and run the threads
+        threadOne.start();
+        threadTwo.start();
+        threadThree.start();
+
+        // join the threads
+        threadOne.join();
+        threadTwo.join();
+        threadThree.join();
+    }
+}


### PR DESCRIPTION
Added a http endpoint to monitor an applications SLA status.

How it works:
1. Message comes in from Kafka
2. The message is parsed and the TS is sent to SlaClient.checkTS()
3. The timestamp is older than the allowed SLA
4. The Boolean _isSlaMet is updated to `false` value
5. The monitoring server is using <servername>/__sla endpoint to look for non `true` values and alerts pagerduty