### PR TITLE
Stop appending `.hostname` to statsd keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Option                                       Description
 --heap-stats-interval-ms [Integer]           Interval (ms) for used heap statsd gauge (default: 1000) 
 --http-port [Integer]                        Accept http connections on this port (0 = web server     
                                                will not start) (default: 0)                           
---log-level                                  Default log4j log level (default: DEBUG)                               
+--log-level                                  Default log4j log level (default: DEBUG)                 
 --stats                                      Enable/disable statsd broadcast                          
---stats-environment                          Stats environment (dictates statsd prefix) (default: dev)
+--stats-environment                          IGNORED for backward compatibility                       
 --stats-host                                 Listening statsd host (default: localhost)               
 --stats-port [Integer]                       Listening statsd port (default: 8125)
 --property-file [String]                     Path to an external property file, containing names of external resources

--- a/krux-stdlib-logging/pom.xml
+++ b/krux-stdlib-logging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.krux</groupId>
         <artifactId>krux-stdlib</artifactId>
-        <version>5.0.3</version>
+        <version>6.0.0</version>
     </parent>
 
     <name>krux-stdlib-logging</name>

--- a/krux-stdlib-monitoring/pom.xml
+++ b/krux-stdlib-monitoring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
       <groupId>com.krux</groupId>
       <artifactId>krux-stdlib</artifactId>
-      <version>5.0.3</version>
+      <version>6.0.0</version>
     </parent>
 
     <name>krux-stdlib-monitoring</name>

--- a/krux-stdlib-monitoring/pom.xml
+++ b/krux-stdlib-monitoring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.krux</groupId>
         <artifactId>krux-stdlib</artifactId>
-        <version>5.0.3</version>
+        <version>5.1.0</version>
     </parent>
 
     <name>krux-stdlib-monitoring</name>

--- a/krux-stdlib-monitoring/pom.xml
+++ b/krux-stdlib-monitoring/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.krux</groupId>
-        <artifactId>krux-stdlib</artifactId>
-        <version>5.1.0</version>
+      <groupId>com.krux</groupId>
+      <artifactId>krux-stdlib</artifactId>
+      <version>5.0.3</version>
     </parent>
 
     <name>krux-stdlib-monitoring</name>

--- a/krux-stdlib-monitoring/src/main/java/com/krux/stdlib/KruxStdLib.java
+++ b/krux-stdlib-monitoring/src/main/java/com/krux/stdlib/KruxStdLib.java
@@ -383,6 +383,7 @@ public class KruxStdLib {
             final String defaultLogLevel = System.getProperty(KRUX_LOGGER_LEVEL_PROPERTY, "WARN");
             final String defaultAppName = System.getProperty(KRUX_APP_NAME_PROPERTY, getMainClassName());
             final String baseAppDirDefault = System.getProperty(KRUX_APP_DIR_PROPERTY, "/tmp");
+            // TODO - remove statsEnvironment and related
             final String statsEnvironmentDefault = System.getProperty(KRUX_STATS_ENVIRONMENT_PROPERTY, "dev");
             final int slaInSecondsDefault = 300;
             final Integer httpListenerPort = 0;
@@ -426,7 +427,8 @@ public class KruxStdLib {
                     .withOptionalArg()
                     .ofType( String.class )
                     .defaultsTo( baseAppDirDefault );
-            OptionSpec<String> statsEnvironmentOption = parser.accepts( "stats-environment", "Stats environment (dictates statsd prefix)" )
+            // TODO - remove statsEnvironment and related
+            OptionSpec<String> statsEnvironmentOption = parser.accepts( "stats-environment", "IGNORED for backwards compatibility." )
                     .withOptionalArg()
                     .ofType( String.class )
                     .defaultsTo( statsEnvironmentDefault );
@@ -477,6 +479,7 @@ public class KruxStdLib {
             configFileLocation = optionSet.valueOf(configFileLocationOption);
 
             enableStatsd = optionSet.has(enableStatsdOption);
+            // TODO - remove statsEnvironment and related
             statsdEnv = optionSet.valueOf( statsEnvironmentOption );
             statsdHost = optionSet.valueOf(statsdHostOption);
             statsdPort = optionSet.valueOf(statsdPortOption);
@@ -506,6 +509,7 @@ public class KruxStdLib {
             System.setProperty(KRUX_STATS_ENABLED_PROPERTY, enableStatsd ? "true" : "false");
             System.setProperty(KRUX_STATS_HOST_PROPERTY, statsdHost);
             System.setProperty(KRUX_STATS_PORT_PROPERTY, statsdPort.toString());
+            // TODO - remove statsEnvironment and related
             System.setProperty(KRUX_STATS_ENVIRONMENT_PROPERTY, statsdEnv);
         }
 

--- a/krux-stdlib-monitoring/src/main/java/com/krux/stdlib/statsd/KruxStatsdClient.java
+++ b/krux-stdlib-monitoring/src/main/java/com/krux/stdlib/statsd/KruxStatsdClient.java
@@ -19,7 +19,6 @@ public class KruxStatsdClient extends StatsdClient {
     final static Logger log = LoggerFactory.getLogger( KruxStatsdClient.class );
 
     private String keyNamespace;
-    private String statsdSuffix;
 
     public KruxStatsdClient( String host, int port, Logger logger, KruxStdLib stdLib ) throws Exception {
         super( host, port, logger );
@@ -28,17 +27,6 @@ public class KruxStatsdClient extends StatsdClient {
 
     protected void init(KruxStdLib stdLib) {
         keyNamespace = stdLib.getStatsdEnv().toLowerCase() + "." + stdLib.getAppName().toLowerCase() + ".";
-        try {
-            String hostName = InetAddress.getLocalHost().getHostName().toLowerCase();
-            if ( hostName.contains( "." ) ) {
-                String[] parts = hostName.split( "\\." );
-                hostName = parts[0];
-            }
-            statsdSuffix = "." + hostName;
-        } catch ( Exception e ) {
-            log.warn( "Cannot get a real hostname, defaulting to something stupid" );
-            statsdSuffix = "." + "unknown";
-        }
     }
 
     public boolean gauge( String key, long value ) {
@@ -50,7 +38,6 @@ public class KruxStatsdClient extends StatsdClient {
     }
 
     private String fullKey( String appKey ) {
-        return keyNamespace + appKey.toLowerCase() + statsdSuffix;
+        return keyNamespace + appKey.toLowerCase();
     }
-
 }

--- a/krux-stdlib-monitoring/src/main/java/com/krux/stdlib/statsd/KruxStatsdClient.java
+++ b/krux-stdlib-monitoring/src/main/java/com/krux/stdlib/statsd/KruxStatsdClient.java
@@ -26,7 +26,7 @@ public class KruxStatsdClient extends StatsdClient {
     }
 
     protected void init(KruxStdLib stdLib) {
-        keyNamespace = stdLib.getStatsdEnv().toLowerCase() + "." + stdLib.getAppName().toLowerCase() + ".";
+        keyNamespace = stdLib.getAppName().toLowerCase() + ".";
     }
 
     public boolean gauge( String key, long value ) {

--- a/krux-stdlib-monitoring/src/test/java/com/krux/stdlib/statsd/KruxStatsdClientTest.java
+++ b/krux-stdlib-monitoring/src/test/java/com/krux/stdlib/statsd/KruxStatsdClientTest.java
@@ -1,0 +1,41 @@
+package com.krux.stdlib.statsd;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import joptsimple.OptionSet;
+import java.net.URL;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import com.krux.stdlib.KruxStdLib;
+import com.krux.stdlib.status.StatusHandler;
+import com.krux.stdlib.statsd.KruxStatsdClient;
+
+import com.krux.stdlib.utils.DummyStatusHandler;
+
+public class KruxStatsdClientTest {
+    private KruxStdLib stdlib;
+    private StatusHandler handler = new DummyStatusHandler();
+
+    @Before
+    public void setUp() throws Exception {
+        URL testPropertyFileURL = Thread.currentThread().getContextClassLoader().getResource("test_properties.properties");
+
+        // initialize
+        stdlib = new KruxStdLib();
+        KruxStdLib.ArgBuilder builder = new KruxStdLib.ArgBuilder().
+            withPropertyFileName(testPropertyFileURL.getPath()).
+            withEnableStatsd(true);
+
+        stdlib.initialize(stdlib.parse(builder), handler);
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        StatsdClient ksc = stdlib.getStatsdClient();
+        assertNotNull(ksc);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.krux</groupId>
     <artifactId>krux-stdlib</artifactId>
-    <version>5.0.3</version>
+    <version>6.0.0</version>
     <packaging>pom</packaging>
 
     <name>Std Lib Parent</name>


### PR DESCRIPTION
# WAT

Removes the code that appended `.hostname` to all statsd keys.

# Y THO?

Datadog migration. We already get a hostname tag from the Datadog collector so doing it here creates duplicate keys that becomes annoying later on.
